### PR TITLE
Handle "rc" suffix in matplotlib version parsing.

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -192,8 +192,13 @@ def _check_min_matplotlib_version(*min_version_pieces):
         else:
             return int(piece)
 
+    def trimrc(ver):
+        if ver.endswith('rc'):
+            return ver[:-len('rc')]
+        return ver
+
     version_pieces = [version_piece_to_int(x)
-                      for x in matplotlib.__version__.split('.')]
+                      for x in trimrc(matplotlib.__version__).split('.')]
 
     return _check_min_version(version_pieces, min_version_pieces)
 


### PR DESCRIPTION
Hi Alex,

I modified the file Util.py to trim the "rc" suffix (if any) in matplotlib.**version**. The matplotlib from Ubuntu 12.04 LTS official source has a version name of "1.1.1rc", which would trigger the following exception:

Traceback (most recent call last):
  File "test.py", line 16, in <module>
    plot.save('test.svg')
  File "/usr/local/lib/python2.7/dist-packages/boomslang/Plot.py", line 516, in save
    layout.save(filename,**kwargs)
  File "/usr/local/lib/python2.7/dist-packages/boomslang/PlotLayout.py", line 310, in save
    fig = self._doPlot()
  File "/usr/local/lib/python2.7/dist-packages/boomslang/PlotLayout.py", line 283, in _doPlot
    if _check_min_matplotlib_version(1, 1, 0):
  File "/usr/local/lib/python2.7/dist-packages/boomslang/Utils.py", line 196, in _check_min_matplotlib_version
    for x in matplotlib.__version__.split('.')]
  File "/usr/local/lib/python2.7/dist-packages/boomslang/Utils.py", line 193, in version_piece_to_int
    return int(piece)
ValueError: invalid literal for int() with base 10: '1rc'

Thanks.
