### PR TITLE
Support for broken-horizontal-bars

### DIFF
--- a/BrokenBarH.py
+++ b/BrokenBarH.py
@@ -1,0 +1,70 @@
+from matplotlib import pyplot
+from PlotInfo import PlotInfo
+
+class BrokenBarH(PlotInfo):
+    """
+    A plot element that represents a collection of horizontal bars spanning a
+    sequence of [xMin, xMax] ranges at a given y.
+    """
+
+    def __init__(self,
+                 y=None,
+                 xMins = [],
+                 xWidths = [],
+                 yWidth=0.6,
+                 linewidth=1.0,
+                 color="black",
+                 edgeColor=None,
+                 **kwargs):
+        super(BrokenBarH,self).__init__("broken barh", **kwargs)
+
+        self.y = y
+        """
+        The y coordinate for this collection of horizontal bars
+        """
+
+        self.xMins = xMins
+        """
+        A list of locations for the start xValues of the horizontal bars
+        """
+
+        self.xWidths = xWidths
+        """
+        A list of widths of the horizontal bars
+        """
+
+        self.yWidth = yWidth
+        """
+        The bar's width along the y axis
+        """
+
+        self.linewidth = linewidth
+        """
+        The width of the line that borders the bars
+        """
+
+        self.color = color
+        """
+        The bar's color. See :ref:`styling-colors` for valid colors.
+        """
+
+        self.edgeColor = edgeColor
+        """
+        The color of the line that borders the bars
+        """
+
+    def draw(self, fig, axis, transform=None):
+        # Draw only if we have a valid y value for the horizontal bars
+        if self.y is None:
+            return [[], []]
+
+        xranges = [(self.xMins[i], self.xWidths[i]) for i in xrange(len(self.xMins))]
+        yrange = (self.y - 0.5 * self.yWidth, self.yWidth)
+
+        kwdict = self.getAttributes()
+        kwdict["linewidth"] = self.linewidth
+        kwdict["edgecolor"] = self.edgeColor
+        kwdict["facecolors"] = self.color
+        kwdict["label"] = self.label
+
+        return [[axis.broken_barh(xranges, yrange, **kwdict)], [self.label]]

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ["Bar", "Plot", "PlotLayout", "WeightedPlotLayout",
            "Scatter", "ClusteredBars", "PlotInfo", "Line", "VLine", "HLine",
            "Utils", "BoxAndWhisker", "StackedBars", "Label", "StackedLines",
-           "BrokenAxisPlot"]
+           "BrokenAxisPlot", "BrokenBarH"]
 
 for __mySrcDir__ in __all__:
     exec("from %s import *" % (__mySrcDir__))


### PR DESCRIPTION
This is useful for plotting Gantt charts.

Example:

```
bbh1 = BrokenBarH()
bbh1.y = 3
bbh1.xMins = [2, 8]
bbh1.xWidths = [2, 4]
bbh1.color = "Red"

bbh2 = BrokenBarH()
bbh2.y = 5
bbh2.xMins = [3, 7, 10]
bbh2.xWidths = [2, 1, 4]
bbh2.color = "Blue"

plot = Plot()
plot.add(bbh1)
plot.add(bbh2)
plot.plot()
```
