### PR TITLE
Specify label for only one xValue of VLine

### DIFF
--- a/VLine.py
+++ b/VLine.py
@@ -87,4 +87,5 @@ class VLine(PlotInfo):
 
         return [[axis.axvline(x=xValue, **kwdict)
                     for xValue in self.xValues],
-                [self.label for xValue in self.xValues]]
+                [self.label if (index == 0) else None
+                    for index in xrange(len(self.xValues))]]


### PR DESCRIPTION
All xValues of a particular VLine use the same style. So we just need to
specify the label in the legend for one of the xValues.
