### PR TITLE
Enable tight bounds with legend as extra artist

### DIFF
--- a/Legend.py
+++ b/Legend.py
@@ -27,6 +27,7 @@ class Legend(object):
         self.title = title
         self.labelOrdering = labelOrdering
         self.leftToRight = leftToRight
+        self.legend = None
 
     def _genLegendKeywords(self):
         legendKeywords = {}
@@ -73,11 +74,14 @@ class Legend(object):
             labels = _flip(labels, self.columns)
 
         if self.figLegend:
-            legend = figure.legend(handles, labels, loc=self.location,
+            self.legend = figure.legend(handles, labels, loc=self.location,
                                    **legendKeywords)
         else:
-            legend = axes.legend(handles, labels, loc=self.location,
+            self.legend = axes.legend(handles, labels, loc=self.location,
                                  **legendKeywords)
 
-        if legend is not None:
-            legend.draw_frame(self.drawFrame)
+        if self.legend is not None:
+            self.legend.draw_frame(self.drawFrame)
+
+    def get_window_extent(self, *args, **kwargs):
+        return self.legend.get_window_extent(*args, **kwargs)


### PR DESCRIPTION
See http://stackoverflow.com/a/10154763/392880 for an example of moving the legend outside the plot. Adding plot.legend to bbox_extra_artists and bbox_inches='tight' in Plot.save() with the legend bbox_to_anchor set outside the plot works correctly.

This isn't the cleanest solution. It might be better to enable this behind the scenes so that if the legend is ever anchored outside the plot it just works. Such a case could probably access the matplotlib legend directly avoiding the get_window_extent function passing through the Legend object.
