### PR TITLE
Pass functions through to matplotlib legend

### DIFF
--- a/Legend.py
+++ b/Legend.py
@@ -83,5 +83,5 @@ class Legend(object):
         if self.legend is not None:
             self.legend.draw_frame(self.drawFrame)
 
-    def get_window_extent(self, *args, **kwargs):
-        return self.legend.get_window_extent(*args, **kwargs)
+    def __getattr__(self, name):
+        return getattr(self.legend, name)


### PR DESCRIPTION
A new version of matplotlib is attempting to call more get_\* functions on the boomslang legend object. Change the legend object to pass any unrecognised functions to the matplotlib legend object.
